### PR TITLE
Potential security issue in src/tool_operate.c: Unchecked return from initialization function

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -444,6 +444,7 @@ static CURLcode post_per_transfer(struct GlobalConfig *global,
       RETRY_LAST /* not used */
     } retry = RETRY_NO;
     long response;
+    response = 0;
     if((CURLE_OPERATION_TIMEDOUT == result) ||
        (CURLE_COULDNT_RESOLVE_HOST == result) ||
        (CURLE_COULDNT_RESOLVE_PROXY == result) ||
@@ -453,6 +454,7 @@ static CURLcode post_per_transfer(struct GlobalConfig *global,
     else if(config->retry_connrefused &&
             (CURLE_COULDNT_CONNECT == result)) {
       long oserrno;
+    oserrno = 0;
       curl_easy_getinfo(curl, CURLINFO_OS_ERRNO, &oserrno);
       if(ECONNREFUSED == oserrno)
         retry = RETRY_CONNREFUSED;
@@ -464,6 +466,7 @@ static CURLcode post_per_transfer(struct GlobalConfig *global,
          returned due to such an error, check for HTTP transient
          errors to retry on. */
       long protocol;
+      protocol = 0;
       curl_easy_getinfo(curl, CURLINFO_PROTOCOL, &protocol);
       if((protocol == CURLPROTO_HTTP) || (protocol == CURLPROTO_HTTPS)) {
         /* This was HTTP(S) */
@@ -492,6 +495,7 @@ static CURLcode post_per_transfer(struct GlobalConfig *global,
     } /* if CURLE_OK */
     else if(result) {
       long protocol;
+      protocol = 0;
 
       curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response);
       curl_easy_getinfo(curl, CURLINFO_PROTOCOL, &protocol);
@@ -585,6 +589,7 @@ static CURLcode post_per_transfer(struct GlobalConfig *global,
     /* Metalink: Decide to try the next resource or not. Try the next resource
        if download was not successful. */
     long response;
+        response = 0;
     if(CURLE_OK == result) {
       /* TODO We want to try next resource when download was
          not successful. How to know that? */


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> When an initialization function is used to initialize a local variable, but the returned status code is not checked, reading the variable may result in undefined behaviour.</span>
---

7 instances of this defect were found in the following locations:
---
**Instance 1**
File : `src/tool_operate.c` 
Function: `curl_easy_getinfo` 
https://github.com/maximus009/curl/blob/02ca5a3ede35eb3db9cdc80f20c814308ffd6a61/src/tool_operate.c#L454
Code extract:

```cpp
    else if(config->retry_connrefused &&
            (CURLE_COULDNT_CONNECT == result)) {
      long oserrno;
      curl_easy_getinfo(curl, CURLINFO_OS_ERRNO, &oserrno); <------ HERE
      if(ECONNREFUSED == oserrno)
        retry = RETRY_CONNREFUSED;
```

---
**Instance 2**
File : `src/tool_operate.c` 
Function: `curl_easy_getinfo` 
https://github.com/maximus009/curl/blob/02ca5a3ede35eb3db9cdc80f20c814308ffd6a61/src/tool_operate.c#L465
Code extract:

```cpp
         returned due to such an error, check for HTTP transient
         errors to retry on. */
      long protocol;
      curl_easy_getinfo(curl, CURLINFO_PROTOCOL, &protocol); <------ HERE
      if((protocol == CURLPROTO_HTTP) || (protocol == CURLPROTO_HTTPS)) {
        /* This was HTTP(S) */
```

---
**Instance 3**
File : `src/tool_operate.c` 
Function: `curl_easy_getinfo` 
https://github.com/maximus009/curl/blob/02ca5a3ede35eb3db9cdc80f20c814308ffd6a61/src/tool_operate.c#L468
Code extract:

```cpp
      curl_easy_getinfo(curl, CURLINFO_PROTOCOL, &protocol);
      if((protocol == CURLPROTO_HTTP) || (protocol == CURLPROTO_HTTPS)) {
        /* This was HTTP(S) */
        curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response); <------ HERE

        switch(response) {
```

---
**Instance 4**
File : `src/tool_operate.c` 
Function: `curl_easy_getinfo` 
https://github.com/maximus009/curl/blob/02ca5a3ede35eb3db9cdc80f20c814308ffd6a61/src/tool_operate.c#L494
Code extract:

```cpp
    else if(result) {
      long protocol;

      curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response); <------ HERE
      curl_easy_getinfo(curl, CURLINFO_PROTOCOL, &protocol);

```

---
**Instance 5**
File : `src/tool_operate.c` 
Function: `curl_easy_getinfo` 
https://github.com/maximus009/curl/blob/02ca5a3ede35eb3db9cdc80f20c814308ffd6a61/src/tool_operate.c#L495
Code extract:

```cpp
      long protocol;

      curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response);
      curl_easy_getinfo(curl, CURLINFO_PROTOCOL, &protocol); <------ HERE

      if((protocol == CURLPROTO_FTP || protocol == CURLPROTO_FTPS) &&
```

---
**Instance 6**
File : `src/tool_operate.c` 
Function: `curl_easy_getinfo` 
https://github.com/maximus009/curl/blob/02ca5a3ede35eb3db9cdc80f20c814308ffd6a61/src/tool_operate.c#L594
Code extract:

```cpp
      if(effective_url &&
         curl_strnequal(effective_url, "http", 4)) {
        /* This was HTTP(S) */
        curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response); <------ HERE
        if(response != 200 && response != 206) {
          per->metalink_next_res = 1;
```

---
**Instance 7**
File : `src/tool_operate.c` 
Function: `post_per_transfer` 
https://github.com/maximus009/curl/blob/02ca5a3ede35eb3db9cdc80f20c814308ffd6a61/src/tool_operate.c#L2139
Code extract:

```cpp
          curl_easy_getinfo(easy, CURLINFO_PRIVATE, (void *)&ended);
          curl_multi_remove_handle(multi, easy);

          result = post_per_transfer(global, ended, result, &retry); <------ HERE
          if(retry)
            continue;
```

