### PR TITLE
Potential security issue in src/tool_urlglob.c: Unchecked return from initialization function

### DIFF
--- a/src/tool_urlglob.c
+++ b/src/tool_urlglob.c
@@ -200,6 +200,7 @@ static CURLcode glob_range(URLGlob *glob, char **patternp,
     if(rc == 3) {
       if(end_c == ':') {
         char *endp;
+        endp = (void*)0;
         errno = 0;
         step = strtoul(&pattern[4], &endp, 10);
         if(errno || &pattern[4] == endp || *endp != ']')


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> When an initialization function is used to initialize a local variable, but the returned status code is not checked, reading the variable may result in undefined behaviour.</span>
---

1 instance of this defect were found in the following locations:
---
**Instance 1**
File : `src/tool_urlglob.c` 
Function: `strtoul` 
https://github.com/maximus009/curl/blob/02ca5a3ede35eb3db9cdc80f20c814308ffd6a61/src/tool_urlglob.c#L204
Code extract:

```cpp
      if(end_c == ':') {
        char *endp;
        errno = 0;
        step = strtoul(&pattern[4], &endp, 10); <------ HERE
        if(errno || &pattern[4] == endp || *endp != ']')
          step = 0;
```

